### PR TITLE
Ajustar renderizado de formulas

### DIFF
--- a/src/OfertaDemanda.Desktop/Controls/MathBlock.axaml
+++ b/src/OfertaDemanda.Desktop/Controls/MathBlock.axaml
@@ -4,7 +4,8 @@
   <StackPanel x:Name="RootPanel"
               Spacing="4">
     <Image x:Name="FormulaImage"
-           Stretch="None" />
+           Stretch="Uniform"
+           StretchDirection="DownOnly" />
     <TextBlock x:Name="HintText"
                FontSize="11"
                Opacity="0.7"

--- a/src/OfertaDemanda.Desktop/Views/MarketView.axaml
+++ b/src/OfertaDemanda.Desktop/Views/MarketView.axaml
@@ -58,6 +58,8 @@
                               Latex="{Binding TotalCostFormulaLatex}"
                               FontSize="14"
                               Inline="True"
+                              MaxWidth="160"
+                              HorizontalAlignment="Right"
                               Margin="8,0,0,0" />
         </Grid>
         <TextBlock Text="{Binding Localization[Market_CostType]}" />
@@ -158,6 +160,7 @@
               <controls:MathBlock Latex="{Binding Localization[Market_Explanation_MC_Title]}"
                                   FontSize="16" />
               <controls:MathBlock Latex="{Binding Localization[Market_Explanation_MC_Formula]}"
+                                  Margin="0,6,0,0"
                                   FontSize="15" />
               <TextBlock Text="{Binding Localization[Market_Explanation_MC_Body]}"
                          FontSize="12"
@@ -167,6 +170,7 @@
               <controls:MathBlock Latex="{Binding Localization[Market_Explanation_AVC_Title]}"
                                   FontSize="16" />
               <controls:MathBlock Latex="{Binding Localization[Market_Explanation_AVC_Formula]}"
+                                  Margin="0,6,0,0"
                                   FontSize="15" />
               <TextBlock Text="{Binding Localization[Market_Explanation_AVC_Body]}"
                          FontSize="12"
@@ -176,6 +180,7 @@
               <controls:MathBlock Latex="{Binding Localization[Market_Explanation_AC_Title]}"
                                   FontSize="16" />
               <controls:MathBlock Latex="{Binding Localization[Market_Explanation_AC_Formula]}"
+                                  Margin="0,6,0,0"
                                   FontSize="15" />
               <TextBlock Text="{Binding Localization[Market_Explanation_AC_Body]}"
                          FontSize="12"

--- a/src/OfertaDemanda.Shared/Math/CSharpMathFormulaRenderer.cs
+++ b/src/OfertaDemanda.Shared/Math/CSharpMathFormulaRenderer.cs
@@ -19,7 +19,7 @@ public sealed class CSharpMathFormulaRenderer : IMathFormulaRenderer
             return new MathRenderResult(Array.Empty<byte>(), 0, 0);
         }
 
-        var key = $"{latex}|{fontSize:F2}|{theme}|{dpiScale:F2}";
+        var key = $"{latex}|{fontSize:F2}|{theme}";
         lock (_lock)
         {
             if (_cache.TryGetValue(key, out var cached))
@@ -34,7 +34,7 @@ public sealed class CSharpMathFormulaRenderer : IMathFormulaRenderer
             LaTeX = latex,
             FontSize = fontSize,
             TextColor = color,
-            Magnification = System.Math.Max(1f, dpiScale),
+            Magnification = 1f,
             AntiAlias = true
         };
 


### PR DESCRIPTION
## Resumen\n- Ajusta el renderizado de formulas para evitar tamaño excesivo (sin escalado por DPI).\n- Recalcula el tamaño en MathBlock y fuerza el ancho del bitmap.\n- Mejora el interlineado en formulas dobles de Mercado.\n\n## Pruebas\n- dotnet build OfertaDemanda.sln -c Debug